### PR TITLE
Minor changes to logging outputs and moved log config to top for availability

### DIFF
--- a/HLD.py
+++ b/HLD.py
@@ -1,10 +1,11 @@
 import json
 import logging
 from lxml import etree
-
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+    
 def create_drawio_vnet_hub_and_spokes_diagram(filename, topology_file):
-    # Configure logging
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
 
     # Load the topology JSON data
     with open(topology_file, 'r') as file:
@@ -326,7 +327,12 @@ def create_drawio_vnet_hub_and_spokes_diagram(filename, topology_file):
     tree = etree.ElementTree(mxfile)
     with open(filename, "wb") as f:
         tree.write(f, encoding="utf-8", xml_declaration=True, pretty_print=True)
+    logging.info(f"Draw.io diagram generated and saved to {filename}")
+
 
 # Generate the diagram from the JSON file
-create_drawio_vnet_hub_and_spokes_diagram("network_hld.drawio", "network_topology.json")
-print("Diagram generation complete.")
+if __name__ == "__main__":
+    logging.info("Starting HLD diagram generation...")
+    create_drawio_vnet_hub_and_spokes_diagram("network_hld.drawio", "network_topology.json")
+    logging.info("Diagram generation complete.")
+    print("Diagram generation complete.")

--- a/MLD.py
+++ b/MLD.py
@@ -1,11 +1,10 @@
 import json
 import logging
 from lxml import etree
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 def create_drawio_vnet_hub_and_spokes_diagram(filename, topology_file):
-    # Configure logging
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
     # Load the topology JSON data
     with open(topology_file, 'r') as file:
         topology = json.load(file)
@@ -418,7 +417,7 @@ def create_drawio_vnet_hub_and_spokes_diagram(filename, topology_file):
 
 # Generate the diagram from the JSON file
 if __name__ == "__main__":
-    logging.info("Starting diagram generation...")
+    logging.info("Starting MLD diagram generation...")
     create_drawio_vnet_hub_and_spokes_diagram("network_mld.drawio", "network_topology.json")
     logging.info("Diagram generation complete.")
     print("Diagram generation complete.")


### PR DESCRIPTION
Moved logging config to top, for it to be handled in both HLD and MLD files (example; the `Loaded topology data from JSON` was not output for MLD.py)
Added added entry point check to HLD.py for consistency across the two diagram generation types, as well as "output" file log print
Slight addition to log line mentioning diagram type.

Also; really cool tool! Been looking at doing something similar for diagnostic settings albeit with output in PlantUML format - might look into the draw.io possibility!