### PR TITLE
fix: add missing library to pyproject.toml, 'six'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ random: setup
 	@cd utils && python3 topology-randomizer.py --iterations 25 --vnets 100 --max-centralization 10 --max-connectivity 10 --max-isolation 10 --parallel-jobs 5 $(ENSURE_FLAG)
 
 # Build package for distribution
-build: setup
+build: clean-build setup
 	@echo "Building package..."
 	@uv build
 	@echo "Package built successfully"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cloudnetdraw"
-version = "0.1.4"
+version = "0.1.5"
 description = "Azure VNet topology discovery and visualization tool that generates Draw.io diagrams"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Add missing library to pyproject.toml to make uvx remote runs work correctly.

```
❯ uvx cloudnetdraw --help

Installed 26 packages in 55ms
Traceback (most recent call last):
  File "/Users/jimweller/.cache/uv/archive-v0/cCTVkiOq395QTH3XwdUto/bin/cloudnetdraw", line 6, in <module>
    from cloudnetdraw.cli import main
  File "/Users/jimweller/.cache/uv/archive-v0/cCTVkiOq395QTH3XwdUto/lib/python3.14/site-packages/cloudnetdraw/cli.py", line 13, in <module>
    from .azure_client import initialize_credentials, get_vnet_topology_for_selected_subscriptions
  File "/Users/jimweller/.cache/uv/archive-v0/cCTVkiOq395QTH3XwdUto/lib/python3.14/site-packages/cloudnetdraw/azure_client.py", line 14, in <module>
    from azure.mgmt.resourcegraph import ResourceGraphClient
  File "/Users/jimweller/.cache/uv/archive-v0/cCTVkiOq395QTH3XwdUto/lib/python3.14/site-packages/azure/mgmt/resourcegraph/__init__.py", line 9, in <module>
    from ._resource_graph_client import ResourceGraphClient
  File "/Users/jimweller/.cache/uv/archive-v0/cCTVkiOq395QTH3XwdUto/lib/python3.14/site-packages/azure/mgmt/resourcegraph/_resource_graph_client.py", line 21, in <module>
    from .operations import ResourceGraphClientOperationsMixin
  File "/Users/jimweller/.cache/uv/archive-v0/cCTVkiOq395QTH3XwdUto/lib/python3.14/site-packages/azure/mgmt/resourcegraph/operations/__init__.py", line 9, in <module>
    from ._resource_graph_client_operations import ResourceGraphClientOperationsMixin
  File "/Users/jimweller/.cache/uv/archive-v0/cCTVkiOq395QTH3XwdUto/lib/python3.14/site-packages/azure/mgmt/resourcegraph/operations/_resource_graph_client_operations.py", line 16, in <module>
    from .. import models as _models
  File "/Users/jimweller/.cache/uv/archive-v0/cCTVkiOq395QTH3XwdUto/lib/python3.14/site-packages/azure/mgmt/resourcegraph/models/__init__.py", line 44, in <module>
    from ._resource_graph_client_enums import (
    ...<4 lines>...
    )
  File "/Users/jimweller/.cache/uv/archive-v0/cCTVkiOq395QTH3XwdUto/lib/python3.14/site-packages/azure/mgmt/resourcegraph/models/_resource_graph_client_enums.py", line 10, in <module>
    from six import with_metaclass
ModuleNotFoundError: No module named 'six'
```