### PR TITLE
feat: add --exclude switch to query sub command to ignore specific vnets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cloudnetdraw"
-version = "0.1.6"
+version = "0.1.7"
 description = "Azure VNet topology discovery and visualization tool that generates Draw.io diagrams"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/uv.lock
+++ b/uv.lock
@@ -379,7 +379,7 @@ wheels = [
 
 [[package]]
 name = "cloudnetdraw"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "azure-identity", version = "1.21.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
Add --exclude switch to ignore specific vnets. Makes it easier to hide helper vnets like security or management that can clutter the view for some audiences. Use the same syntax as the --vnet switch, subscription ide or /sub/rg/vnet path.